### PR TITLE
fix: correct armor penetration angle logic

### DIFF
--- a/Assets/Scripts/ArmorAngleResolver.cs
+++ b/Assets/Scripts/ArmorAngleResolver.cs
@@ -5,13 +5,13 @@ using UnityEngine;
 /// </summary>
 public static class ArmorAngleResolver
 {
-    public const float DefaultCriticalAngle = 45f;          // минимальный угол для урона
+    public const float DefaultCriticalAngle = 45f;          // допустимый угол пробития (°)
 
     /// <summary>
-    /// Возвращает true, если угол превышает критический и можно наносить урон.
+    /// Возвращает true, если угол меньше критического и пуля пробивает броню.
     /// </summary>
     public static bool CanPenetrate(float impactAngle, float criticalAngle = DefaultCriticalAngle)
     {
-        return impactAngle > criticalAngle;                 // наносим урон при большом угле
+        return impactAngle < criticalAngle;                 // проникаем при меньшем угле
     }
 }

--- a/Assets/Scripts/ArmorAngleResolver.cs
+++ b/Assets/Scripts/ArmorAngleResolver.cs
@@ -8,10 +8,10 @@ public static class ArmorAngleResolver
     public const float DefaultCriticalAngle = 45f;          // минимальный угол для урона
 
     /// <summary>
-    /// Возвращает true, если угол меньше критического и можно наносить урон.
+    /// Возвращает true, если угол превышает критический и можно наносить урон.
     /// </summary>
     public static bool CanPenetrate(float impactAngle, float criticalAngle = DefaultCriticalAngle)
     {
-        return impactAngle < criticalAngle;                 // true, если угол достаточен
+        return impactAngle > criticalAngle;                 // наносим урон при большом угле
     }
 }


### PR DESCRIPTION
## Summary
- fix armor penetration condition so bullet penetrates only when impact angle exceeds critical threshold

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb33b4644c8333b90849f93771563f